### PR TITLE
torch<=1.4.0 needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license='Apache',
     url="https://github.com/charles9n/bert-sklearn",
     packages=find_packages(exclude=['test', 'scripts', 'examples']),
-    install_requires=['torch>=0.4.1',
+    install_requires=['torch>=0.4.1,<=1.4.0',
                        'scikit-learn',
                        'numpy',
                        'pandas',


### PR DESCRIPTION
Your work, `bert-sklearn`, is a really great piece of code! Thank you! :)

It seems to me, that it does not work with `torch>1.4.0`,
so `torch` version need to be limited to max `1.4.0`.

Please review and merge.